### PR TITLE
Remove $LD_LIBRARY_PATH variable from LD_LIBRARY_PATH definition.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ apps:
           XDG_DATA_HOME: "$SNAP/usr/share"
           FONTCONFIG_PATH: "$SNAP/etc/fonts"
           JAVA_HOME: "$SNAP/usr/lib/jvm/java-11-openjdk"
-          LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$LD_LIBRARY_PATH"
+          LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET"
         command: |
             usr/lib/jvm/java-11-openjdk/bin/java -DJENKINS_HOME="$SNAP_DATA" -Djava.awt.headless=true -jar $SNAP/jenkins.war
         daemon: simple


### PR DESCRIPTION
$LD_LIBRARY_PATH starts as null and thus leaves a trailing colon.

(See my comments at https://forum.snapcraft.io/t/ann-snapcraft-4-4-4-library-injection-vulnerability-on-built-snaps/21465/5?u=james-carroll )

Edited: Unlike the several other snaps I've made a PR for in the Snapcrafters organisation, Jenkins is a classic snap and does not have any real content in it's snapcraft_runner, including not having the warning for including the CWD. As a result, whilst `::` will not be in $LD_LIBRARY_PATH and no errors will be printed by Snapcraft 4.4.4+, it still ends up including CWD.