### PR TITLE
Logic for upstream version sync added

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -26,7 +26,7 @@ jobs:
             # Update the snapcraft.yaml to match upstream version
             API="https://api.github.com/repos/jenkinsci/jenkins/releases/latest"
             VERSION=$(curl -s "${API}" | grep -i name | awk 'FNR == 3 {print $2}' | cut -d ',' -f1 | sed 's/"//g')
-            CRAFT=$(grep -i version ~/snapcraft.yaml | awk '{print $2}' | sed 's/"//g')
+            CRAFT=$(grep -i version snap/snapcraft.yaml | awk '{print $2}' | sed 's/"//g')
             # Running checks here
             if [[ "${VERSION}" < "${CRAFT}" ]]
             then

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -22,7 +22,15 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
+            #!/bin/bash
             # Update the snapcraft.yaml to match upstream version
             API="https://api.github.com/repos/jenkinsci/jenkins/releases/latest"
-            VERSION=$(curl -s "${API}" | grep -i name | awk 'FNR == 3 {print $2}' | cut -d ',' -f1)
-            sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml
+            VERSION=$(curl -s "${API}" | grep -i name | awk 'FNR == 3 {print $2}' | cut -d ',' -f1 | sed 's/"//g')
+            CRAFT=$(grep -i version ~/snapcraft.yaml | awk '{print $2}' | sed 's/"//g')
+
+            if [[ "${VERSION}" < "${CRAFT}" ]]
+            then
+              exit
+            else
+              sed -i 's/^\(version: \).*$/\1'"'$VERSION'"'/' snap/snapcraft.yaml 
+            fi

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -28,9 +28,6 @@ jobs:
             VERSION=$(curl -s "${API}" | grep -i name | awk 'FNR == 3 {print $2}' | cut -d ',' -f1 | sed 's/"//g')
             CRAFT=$(grep -i version snap/snapcraft.yaml | awk '{print $2}' | sed 's/"//g')
             # Running checks here
-            if [[ "${VERSION}" < "${CRAFT}" ]]
-            then
-              exit
-            else
+            if [[ "${CRAFT}" < "${VERSION}" ]]; then
               sed -i 's/^\(version: \).*$/\1'"'$VERSION'"'/' snap/snapcraft.yaml 
             fi

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -27,7 +27,7 @@ jobs:
             API="https://api.github.com/repos/jenkinsci/jenkins/releases/latest"
             VERSION=$(curl -s "${API}" | grep -i name | awk 'FNR == 3 {print $2}' | cut -d ',' -f1 | sed 's/"//g')
             CRAFT=$(grep -i version ~/snapcraft.yaml | awk '{print $2}' | sed 's/"//g')
-
+            # Running checks here
             if [[ "${VERSION}" < "${CRAFT}" ]]
             then
               exit

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ issues: https://github.com/snapcrafters/jenkins/issues
 source-code: https://github.com//snapcrafters/jenkins
 license: MIT
 icon: snap/local/jenkins.png
-version: "2.426.2"
+version: '2.436'
 
 base: core22
 confinement: classic

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ parts:
   jenkins:
     plugin: nil
     source: https://github.com/jenkinsci/jenkins.git
-    source-tag: jenkins-$SNAPCRAFT_PROJECT_VERSION  
+    source-tag: jenkins-$SNAPCRAFT_PROJECT_VERSION
     stage-packages:
       - fonts-dejavu-core
       - libfontconfig1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,6 @@ parts:
     plugin: nil
     source: https://github.com/jenkinsci/jenkins.git
     source-tag: jenkins-$SNAPCRAFT_PROJECT_VERSION  
-    source-branch: master  
     stage-packages:
       - fonts-dejavu-core
       - libfontconfig1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ issues: https://github.com/snapcrafters/jenkins/issues
 source-code: https://github.com//snapcrafters/jenkins
 license: MIT
 icon: snap/local/jenkins.png
-version: "2.435"
+version: "2.436"
 
 base: core22
 confinement: classic
@@ -40,7 +40,8 @@ parts:
   jenkins:
     plugin: nil
     source: https://github.com/jenkinsci/jenkins.git
-    source-tag: jenkins-$SNAPCRAFT_PROJECT_VERSION    
+    source-tag: jenkins-$SNAPCRAFT_PROJECT_VERSION  
+    source-branch: master  
     stage-packages:
       - fonts-dejavu-core
       - libfontconfig1


### PR DESCRIPTION
Due to the way Jenkins releases their LTS vs Latest, it caused an issue with the latest snap build and release to candidate, where the version built, albeit Jenkins' latest LTS, was not the same branch we've been building against. I am hopeful that this change will prevent it in the future. Otherwise, we can just set a hard number in the file (snap a line on a specific version) and anything greater than that would be built, and lower version numbers wouldn't - I hope.

This is working in local testing but I do not have the same actions set up for my repos, yet, so I have to rely on this to perform the test. 