### PR TITLE
Correcting update logic

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -23,11 +23,13 @@ jobs:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
             #!/bin/bash
-            # Update the snapcraft.yaml to match upstream version
             API="https://api.github.com/repos/jenkinsci/jenkins/releases/latest"
             VERSION=$(curl -s "${API}" | grep -i name | awk 'FNR == 3 {print $2}' | cut -d ',' -f1 | sed 's/"//g')
             CRAFT=$(grep -i version snap/snapcraft.yaml | awk '{print $2}' | sed 's/"//g')
-            # Running checks here
-            if [[ "${CRAFT}" < "${VERSION}" ]]; then
+            # Running checks here to ensure that the version from upstream is actually a greater value than what is shown in the snapcraft.yaml
+            if [[ "${CRAFT}" > "${VERSION}" ]]
+            then
+              exit
+            else
               sed -i 's/^\(version: \).*$/\1'"'$VERSION'"'/' snap/snapcraft.yaml 
             fi

--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -22,14 +22,6 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
-            #!/bin/bash
-            API="https://api.github.com/repos/jenkinsci/jenkins/releases/latest"
-            VERSION=$(curl -s "${API}" | grep -i name | awk 'FNR == 3 {print $2}' | cut -d ',' -f1 | sed 's/"//g')
-            CRAFT=$(grep -i version snap/snapcraft.yaml | awk '{print $2}' | sed 's/"//g')
-            # Running checks here to ensure that the version from upstream is actually a greater value than what is shown in the snapcraft.yaml
-            if [[ "${CRAFT}" > "${VERSION}" ]]
-            then
-              exit
-            else
-              sed -i 's/^\(version: \).*$/\1'"'$VERSION'"'/' snap/snapcraft.yaml 
-            fi
+            # Grabbing latest release
+            VERSION=$(curl -sL https://api.github.com/repos/jenkinsci/jenkins/releases |  jq .[].tag_name -r | grep -v rc | sort -r | head -n 1 | cut -d "-" -f2)
+            sed -i 's/^\(version: \).*$/\1'"'$VERSION'"'/' snap/snapcraft.yaml 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ issues: https://github.com/snapcrafters/jenkins/issues
 source-code: https://github.com//snapcrafters/jenkins
 license: MIT
 icon: snap/local/jenkins.png
-version: '2.436'
+version: '2.435'
 
 base: core22
 confinement: classic


### PR DESCRIPTION
I should have stuck with the original logic instead of accepting some proposed changes to the last PR. I should have explained why the logic was the way I wrote it and also thought thru what was being proposed as an alternative before accepting the proposed change; so that's on me. This PR will be the way the logic is used going forward. 

The script checks to be sure that the released version from Jenkins is of greater value than what is in the `snapcraft.yaml` BEFORE it runs a build. If it is of lower value (Jenkins LTS is lower number than latest), then it'll exit. Otherwise, it will build the newest releases. 