### PR TITLE
Corrects issue with messy Jenkins LTS releases

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -38,5 +38,5 @@ jobs:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
             # Grabbing latest lts release
-            VERSION=$(curl -sL https://api.github.com/repos/jenkinsci/jenkins/releases |  jq .[].tag_name -r | grep -v rc | sort -r | grep "2.440" | head -n1 | cut -d "-" -f2)
+            VERSION=$(curl -s https://api.github.com/repos/jenkinsci/jenkins/releases | jq '.[] | select(.body | test("lts")) | select(.tag_name | test("rc") | not) | {name, tag_name, published_at}'| jq -s 'sort_by(.tag_name) | reverse | .[0]' | grep -w name | awk '{print $2}' | tr -d '"' | cut -d "," -f1) 
             sed -i 's/^\(version: \).*$/\1'"'$VERSION'"'/' snap/snapcraft.yaml 


### PR DESCRIPTION
Jenkins doesn't tag their LTS releases in a JSON format, making it very difficult to create the correct version of the snap for the LTS track. This appears to mitigate that issue but may require massaging in the future, if Jenkins changes their format.

Addresses https://github.com/snapcrafters/jenkins/issues/105 