### PR TITLE
Upgrade to Openjdk 21

### DIFF
--- a/snap/local/launch
+++ b/snap/local/launch
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$SNAP/usr/lib/jvm/java-17-openjdk/bin/java -DJENKINS_HOME="$SNAP_DATA" -Djava.awt.headless=true -jar $SNAP/jenkins.war
+$SNAP/usr/lib/jvm/java-21-openjdk/bin/java -DJENKINS_HOME="$SNAP_DATA" -Djava.awt.headless=true -jar $SNAP/jenkins.war

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ apps:
     environment:
       XDG_DATA_HOME: "$SNAP/usr/share"
       FONTCONFIG_PATH: "$SNAP/etc/fonts"
-      JAVA_HOME: "$SNAP/usr/lib/jvm/java-17-openjdk"
+      JAVA_HOME: "$SNAP/usr/lib/jvm/java-21-openjdk"
       LD_LIBRARY_PATH: "$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}"
     command: launch            
     daemon: simple
@@ -44,7 +44,7 @@ parts:
     stage-packages:
       - fonts-dejavu-core
       - libfontconfig1
-      - openjdk-17-jre-headless
+      - openjdk-21-jre-headless
       - ca-certificates-java
     build-packages:
       - curl
@@ -54,13 +54,13 @@ parts:
     
     override-build: |
       curl -sLO http://mirrors.jenkins.io/war/latest/jenkins.war
-      mv $CRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk-* $CRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk
-      rm $CRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk/lib/security/cacerts
-      cp /etc/ssl/certs/java/cacerts $CRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk/lib/security/cacerts
+      mv $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk-* $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk
+      rm $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk/lib/security/cacerts
+      cp /etc/ssl/certs/java/cacerts $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk/lib/security/cacerts
       cp /etc/ssl/certs/java/cacerts $CRAFT_PART_INSTALL/etc/ssl/certs/java/cacerts
       mv jenkins.war $CRAFT_PART_INSTALL
     prime:
-      - -usr/lib/jvm/java-17-openjdk-*/lib/security/blacklisted.certs
+      - -usr/lib/jvm/java-21-openjdk-*/lib/security/blacklisted.certs
       - -usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs
 
   config:


### PR DESCRIPTION
Jenkins had a warning banner requiring an upgrade to a later version of java (21).  I have already locally tested this at home and we're good. 