### PR TITLE
Fixed prime to keep builds working

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,7 @@ parts:
       mv jenkins.war $CRAFT_PART_INSTALL
     prime:
       - -usr/lib/jvm/java-21-openjdk-*/lib/security/blacklisted.certs
+      - -usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs  
 
   config:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,7 +60,6 @@ parts:
       mv jenkins.war $CRAFT_PART_INSTALL
     prime:
       - -usr/lib/jvm/java-21-openjdk-*/lib/security/blacklisted.certs
-      - -usr/lib/jvm/java-21-openjdk-*/lib/security/blacklisted.certs
 
   config:
     plugin: dump


### PR DESCRIPTION
Added the following entries in the yaml:
```
    prime:
      - -usr/lib/jvm/java-21-openjdk-*/lib/security/blacklisted.certs
      - -usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs  
```