### PR TITLE
Needed a new library

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ issues: https://github.com/snapcrafters/jenkins/issues
 source-code: https://github.com//snapcrafters/jenkins
 license: MIT
 icon: snap/local/jenkins.png
-version: '2.502'
+version: '2.505'
 
 base: core22
 confinement: classic
@@ -46,11 +46,11 @@ parts:
       - libfontconfig1
       - openjdk-21-jre-headless
       - ca-certificates-java
+      - libharfbuzz0b
     build-packages:
       - curl
       - libnss3
       - ca-certificates-java
-      - python3-requests #for API usage
     
     override-build: |
       curl -sLO http://mirrors.jenkins.io/war/latest/jenkins.war


### PR DESCRIPTION
Added to stage-packages:
```
- libharfbuzz0b
```

This is a new issue that cropped up with the last build (9 APR 2025) and Jenkins wouldn't launch. `libharfbuzz0b` was needed to rectify it. 

Screenshot of it running locally:

![image](https://github.com/user-attachments/assets/c0289c6e-80a7-4350-a44e-969292df3d77)
