### PR TITLE
ci: fix the promotion channel for LTS branch

### DIFF
--- a/.github/workflows/release-to-candidate.yml
+++ b/.github/workflows/release-to-candidate.yml
@@ -59,4 +59,4 @@ jobs:
           architectures: ${{ needs.get-architectures.outputs.architectures }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           channel: lts/candidate
-          promotion-channel: lts/candidate
+          promotion-channel: lts/stable


### PR DESCRIPTION
ci: fix the promotion channel

fix the promotion channel from candidate to stable for lts track
