### PR TITLE
snapcraft.yaml: enable riscv64 builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,7 @@ architectures:
   - build-on: amd64
   - build-on: arm64
   - build-on: armhf
+  - build-on: riscv64
 
 apps:
   jenkins:


### PR DESCRIPTION
The Jenkins snap builds fine on riscv64 locally and is usable.

I installed default plugins and successfully customized and executed a
build job using the snap on a riscv64 StarFive VisionFive 2 board.