### PR TITLE
build: fetch `jenkins.war` in a separate part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,20 +49,21 @@ parts:
       - ca-certificates-java
       - libharfbuzz0b
     build-packages:
-      - curl
       - libnss3
       - ca-certificates-java
-    
     override-build: |
-      curl -sLO http://mirrors.jenkins.io/war/latest/jenkins.war
       mv $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk-* $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk
       rm $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk/lib/security/cacerts
       cp /etc/ssl/certs/java/cacerts $CRAFT_PART_INSTALL/usr/lib/jvm/java-21-openjdk/lib/security/cacerts
       cp /etc/ssl/certs/java/cacerts $CRAFT_PART_INSTALL/etc/ssl/certs/java/cacerts
-      mv jenkins.war $CRAFT_PART_INSTALL
     prime:
       - -usr/lib/jvm/java-21-openjdk-*/lib/security/blacklisted.certs
       - -usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs
+
+  jenkins-war:
+    plugin: dump
+    source: http://mirrors.jenkins.io/war/latest/jenkins.war
+    source-type: file
 
   config:
     plugin: dump


### PR DESCRIPTION
The current build process invokes `curl` as part of an `override-build` scriptlet. As a general rule, external artifacts should be pulled in the `PULL` stage.

In general this hasn't been a problem, but on slower runners such as the emulated `riscv` builders currently used by Launchpad, by the time the `override-build` scriptlet is executed, the proxy token has sometimes expired.

This commit is a minor refactor to fetch `jenkins.war` as a separate part, where the actual fetch will happen in the `PULL` phase of the build.

See [here](https://github.com/snapcrafters/jenkins/actions/runs/16468141666/job/46550507055) for example build failures.