### PR TITLE
Removing RISCV64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,7 @@ architectures:
   - build-on: amd64
   - build-on: arm64
   - build-on: armhf
-  - build-on: riscv64
+#  - build-on: riscv64
 
 apps:
   jenkins:


### PR DESCRIPTION
This build keeps failing - week after week. This is impacting other users for other architectures.