### PR TITLE
docs: standardise workflow names and badges [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
 <a href="https://snapcraft.io/jenkins"><img src="https://snapcraft.io/jenkins/badge.svg" alt="Snap Status"></a>
 <a href="https://github.com/snapcrafters/jenkins/actions/workflows/sync-version-with-upstream.yml"><img src="https://github.com/snapcrafters/jenkins/actions/workflows/sync-version-with-upstream.yml/badge.svg"></a>
-<a href="https://github.com/snapcrafters/jenkins/actions/workflows/release-to-candidate.yaml"><img src="https://github.com/snapcrafters/jenkins/actions/workflows/release-to-candidate.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/jenkins/actions/workflows/release-to-candidate.yml"><img src="https://github.com/snapcrafters/jenkins/actions/workflows/release-to-candidate.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/jenkins/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/jenkins/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </p>
 


### PR DESCRIPTION
## Summary
- Standardises workflow filenames and README workflow badge links on `lts`.
- Keeps badge href and image URLs aligned with workflow files present on this branch.

## Workflow renames
- None

## README files
- `README.md`

## Badge/link replacements
- `release-to-candidate.yaml -> release-to-candidate.yml`

## Verification
- `git diff --check`
- Commit message includes `[skip ci]`.

@jnsgruk please review.
